### PR TITLE
Refactor parser to delegate command execution to individual classes to follow SLAP

### DIFF
--- a/src/main/java/backend/Parser.java
+++ b/src/main/java/backend/Parser.java
@@ -1,10 +1,7 @@
 package backend;
 import java.time.LocalDateTime;
 
-import commands.Command;
-import commands.ByeCommand;
-import commands.ListCommand;
-import commands.MarkCommand;
+import commands.*;
 import store.Deadline;
 import store.Event;
 import store.Storage;
@@ -45,79 +42,30 @@ public class Parser {
                 Command mark = new MarkCommand(details);
                 return mark.execute(tasks, storage, ui);
             case "unmark":
-                int unmarkIndex = Integer.parseInt(details) - 1;
-                tasks.markTaskAsNotDone(unmarkIndex);
-                storage.saveTasks(tasks.getTasks());
-                return ui.showTaskUnmarked(tasks.getTask(unmarkIndex));
+                Command unmark = new UnmarkCommand(details);
+                return unmark.execute(tasks, storage, ui);
             case "delete":
-                int deleteIndex = Integer.parseInt(details) - 1;
-                Task deletedTask = tasks.getTask(deleteIndex);
-                tasks.deleteTask(deleteIndex);
-                storage.saveTasks(tasks.getTasks());
-                return ui.showTaskDeleted(deletedTask, tasks.getSize());
+                Command delete = new DeleteCommand(details);
+                return delete.execute(tasks, storage, ui);
             case "todo":
-                if (details.trim().isEmpty()) {
-                    return ui.showError("OOPS!!! The description of a todo cannot be empty.");
-                } else {
-                    Task todo = new Todo(details);
-                    tasks.addTask(todo);
-                    storage.saveTasks(tasks.getTasks());
-                    return ui.showTaskAdded(todo, tasks.getSize());
-                }
+                Command todo = new TodoCommand(details);
+                return todo.execute(tasks, storage, ui);
             case "deadline":
-                if (!details.contains("/by")) {
-                    return ui.showError("OOPS!!! Please follow this format: deadline task /by date");
-                } else {
-                    String[] deadlineParts = details.split("/by", 2);
-                    String task = deadlineParts[0].trim();
-                    String by = deadlineParts[1].trim();
-                    LocalDateTime deadline = DateTimeParser.parseDateTime(by);
-                    Task deadlineTask = new Deadline(task, deadline);
-                    tasks.addTask(deadlineTask);
-                    storage.saveTasks(tasks.getTasks());
-                    return ui.showTaskAdded(deadlineTask, tasks.getSize());
-                }
+                Command deadline = new DeadlineCommand(details);
+                return deadline.execute(tasks, storage, ui);
             case "event":
-                if (!details.contains("/from") || !details.contains("/to")) {
-                    return ui.showError("OOPS!!! Please follow this format: event task /from time /to time");
-                } else {
-                    String[] eventParts = details.split("/from|/to");
-                    String task = eventParts[0].trim();
-                    String from = eventParts[1].trim();
-                    String to = eventParts[2].trim();
-                    LocalDateTime start = DateTimeParser.parseDateTime(from);
-                    LocalDateTime end = DateTimeParser.parseDateTime(to);
-                    Task eventTask = new Event(task, start, end);
-                    tasks.addTask(eventTask);
-                    storage.saveTasks(tasks.getTasks());
-                    return ui.showTaskAdded(eventTask, tasks.getSize());
-                }
+                Command event = new EventCommand(details);
+                return event.execute(tasks, storage, ui);
             case "find":
-                if (details.trim().isEmpty()) {
-                    ui.showError("OOPS!!! The description of a find cannot be empty.");
-                } else {
-                    TaskList relatedTasks = new TaskList();
-                    for (int i = 0; i < tasks.getSize(); i++) {
-                        Task task = tasks.getTask(i);
-                        if (task.getDescription().contains(details)) {
-                            relatedTasks.addTask(task);
-                        }
-                    }
-                    if (relatedTasks.getSize() > 0) {
-                        return ui.showMatchedTasks(relatedTasks);
-                    } else {
-                        return ui.showNoMatchMessage(details);
-                    }
-                }
-                break;
+                Command find = new FindCommand(details);
+                return find.execute(tasks, storage, ui);
             default:
                 return ui.showError("OOPS!!! I'm sorry, but I don't know what that means :(");
             }
         } catch (Exception e) {
             return ui.showError("Invalid input or error processing command. "
-                    + "Note that date and time should be in dd/mm/yyyy tt/mm format");
+                    + "Note that date and time should be in dd/mm/yyyy ttmm format");
         }
-        return "OOPS!!! I'm sorry, but I don't know what that means";
     }
 
     /**

--- a/src/main/java/commands/Command.java
+++ b/src/main/java/commands/Command.java
@@ -21,6 +21,10 @@ public abstract class Command {
         this.details = details;
     }
 
+    public String getDetails() {
+        return this.details;
+    }
+
     /**
      * Method that executes the tasks related to the command
      * @param tasks The TaskList to work with.

--- a/src/main/java/commands/DeadlineCommand.java
+++ b/src/main/java/commands/DeadlineCommand.java
@@ -1,0 +1,104 @@
+package commands;
+
+import backend.DateTimeParser;
+import store.Storage;
+import store.TaskList;
+import store.Deadline;
+import ui.Ui;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+/**
+ * Class representing the Deadline command
+ */
+public class DeadlineCommand extends Command {
+    private String deadlineTask;
+    private String by;
+    private LocalDateTime formattedBy;
+
+    private Deadline deadlineTaskObject;
+
+    /**
+     * Constructor for deadline command
+     * @param details
+     */
+    public DeadlineCommand(String details) {
+        super(details);
+        breakDownTask(details);
+    }
+
+    /**
+     * Method to break down task description into task and due date
+     * @param details of task
+     */
+    public void breakDownTask(String details) {
+        String[] deadlineParts = details.split("/by", 2);
+        deadlineTask = deadlineParts[0].trim();
+        by = deadlineParts[1].trim();
+    }
+
+    /**
+     * Method to format deadline in dd/mm/yyyy tt/mm format
+     * @param by
+     * @return formatted deadline
+     */
+    public void formatDeadline(String by) {
+        formattedBy = DateTimeParser.parseDateTime(by);
+    }
+
+    /**
+     * Method to check if command was formatted correctly
+     * @return False if formatted correctly
+     */
+    public boolean isWrongFormat() {
+        return !super.getDetails().contains("/by");
+    }
+
+    /**
+     * Method to show error message from wrong deadline format
+     * @param ui
+     * @return system message
+     */
+    public String showErrorMessage(Ui ui) {
+        return ui.showError("OOPS!!! Please follow this format: deadline task /by date");
+    }
+
+    /**
+     * Method to add deadline task
+     * @param tasks
+     */
+    public void addDeadlineTask(TaskList tasks) {
+        deadlineTaskObject = new Deadline(deadlineTask, formattedBy);
+        tasks.addTask(deadlineTaskObject);
+    }
+
+    /**
+     * Method to show deadline added message
+     * @param ui
+     * @param tasks
+     * @return system message
+     */
+    public String showDeadlineMessage(Ui ui, TaskList tasks) {
+        return ui.showTaskAdded(deadlineTaskObject, tasks.getSize());
+    }
+
+    /**
+     * Method to execute command
+     * @param tasks The TaskList to work with.
+     * @param storage The Storage to save or load tasks
+     * @param ui The messages the user will see
+     * @return system message
+     * @throws IOException
+     */
+    @Override
+    public String execute(TaskList tasks, Storage storage, Ui ui) throws IOException {
+        if (isWrongFormat()) {
+            return showErrorMessage(ui);
+        }
+        formatDeadline(by);
+        addDeadlineTask(tasks);
+        super.saveTasks(tasks, storage);
+        return showDeadlineMessage(ui, tasks);
+    }
+}

--- a/src/main/java/commands/DeleteCommand.java
+++ b/src/main/java/commands/DeleteCommand.java
@@ -1,0 +1,70 @@
+package commands;
+
+import store.Storage;
+import store.TaskList;
+import store.Task;
+import ui.Ui;
+
+import java.io.IOException;
+
+/**
+ * Class representing the Delete command
+ */
+public class DeleteCommand extends Command {
+
+    private int deleteIndex;
+    private Task deletedTask;
+
+    /**
+     * Constructor for Delete command
+     * @param details of command
+     */
+    public DeleteCommand(String details) {
+        super(details);
+        deleteIndex = Integer.parseInt(details) - 1;
+    }
+
+    /**
+     * Method to execute command
+     * @param tasks The TaskList to work with.
+     * @param storage The Storage to save or load tasks
+     * @param ui The messages the user will see
+     * @return system message
+     * @throws IOException
+     */
+    public String execute(TaskList tasks, Storage storage, Ui ui) throws IOException {
+        deleteTaskFromList(tasks);
+        saveTaskList(tasks, storage);
+        return showDeletionMessage(ui, tasks);
+    }
+
+    /**
+     * Method to delete task
+     * @param tasks
+     */
+    public void deleteTaskFromList(TaskList tasks) {
+        deletedTask = tasks.getTask(deleteIndex);
+        tasks.deleteTask(deleteIndex);
+    }
+
+    /**
+     * Method to save task list
+     * @param tasks
+     * @param storage
+     * @throws IOException
+     */
+    public void saveTaskList(TaskList tasks, Storage storage) throws IOException {
+        super.saveTasks(tasks, storage);
+    }
+
+    /**
+     * Method to return delete message
+     * @param ui
+     * @param tasks
+     * @return system message
+     */
+    public String showDeletionMessage(Ui ui, TaskList tasks) {
+        return ui.showTaskDeleted(deletedTask, tasks.getSize());
+    }
+
+}

--- a/src/main/java/commands/EventCommand.java
+++ b/src/main/java/commands/EventCommand.java
@@ -1,0 +1,98 @@
+package commands;
+
+import backend.DateTimeParser;
+import store.Storage;
+import store.TaskList;
+import store.Event;
+import ui.Ui;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+/**
+ * Class representing the Event command
+ */
+public class EventCommand extends Command {
+    private String eventTask;
+    private String from;
+    private String to;
+    private LocalDateTime start;
+    private LocalDateTime end;
+    private Event eventTaskObject;
+
+    /**
+     * Constructor for EventCommand
+     * @param details The event details string
+     */
+    public EventCommand(String details) {
+        super(details);
+        breakDownTask(details);
+    }
+
+    /**
+     * Method to break down task details into task, start time, and end time
+     * @param details of the task
+     */
+    private void breakDownTask(String details) {
+        String[] eventParts = details.split("/from|/to");
+        eventTask = eventParts[0].trim();
+        from = eventParts[1].trim();
+        to = eventParts[2].trim();
+        start = DateTimeParser.parseDateTime(from);
+        end = DateTimeParser.parseDateTime(to);
+    }
+
+    /**
+     * Method to check if command was formatted correctly
+     * @return True if incorrectly formatted
+     */
+    public boolean isWrongFormat() {
+        return !(super.getDetails().contains("/from") && super.getDetails().contains("/to"));
+    }
+
+    /**
+     * Method to show error message for incorrect format
+     * @param ui UI to display the message
+     * @return system error message
+     */
+    public String showErrorMessage(Ui ui) {
+        return ui.showError("OOPS!!! Please follow this format: event task /from time /to time");
+    }
+
+    /**
+     * Method to add event task to the task list
+     * @param tasks TaskList to add the event
+     */
+    private void addEventTask(TaskList tasks) {
+        eventTaskObject = new Event(eventTask, start, end);
+        tasks.addTask(eventTaskObject);
+    }
+
+    /**
+     * Method to show event added message
+     * @param ui UI to display the message
+     * @param tasks TaskList to check size
+     * @return system message
+     */
+    private String showEventMessage(Ui ui, TaskList tasks) {
+        return ui.showTaskAdded(eventTaskObject, tasks.getSize());
+    }
+
+    /**
+     * Method to execute command
+     * @param tasks The TaskList to work with.
+     * @param storage The Storage to save or load tasks
+     * @param ui The messages the user will see
+     * @return system message
+     * @throws IOException
+     */
+    @Override
+    public String execute(TaskList tasks, Storage storage, Ui ui) throws IOException {
+        if (isWrongFormat()) {
+            return showErrorMessage(ui);
+        }
+        addEventTask(tasks);
+        super.saveTasks(tasks, storage);
+        return showEventMessage(ui, tasks);
+    }
+}

--- a/src/main/java/commands/FindCommand.java
+++ b/src/main/java/commands/FindCommand.java
@@ -1,0 +1,69 @@
+package commands;
+
+import store.Storage;
+import store.TaskList;
+import store.Task;
+import ui.Ui;
+
+import java.io.IOException;
+
+/**
+ * Class representing the Find command
+ */
+public class FindCommand extends Command {
+    private String keyword;
+
+    /**
+     * Constructor for FindCommand
+     * @param details The keyword to search for
+     */
+    public FindCommand(String details) {
+        super(details);
+        this.keyword = details.trim();
+    }
+
+    /**
+     * Method to check if search keyword is empty
+     * @return True if keyword is empty
+     */
+    public boolean isEmptyKeyword() {
+        return keyword.isEmpty();
+    }
+
+    /**
+     * Method to search for matching tasks
+     * @param tasks TaskList to search
+     * @return TaskList of matching tasks
+     */
+    private TaskList getMatchingTasks(TaskList tasks) {
+        TaskList relatedTasks = new TaskList();
+        for (int i = 0; i < tasks.getSize(); i++) {
+            Task task = tasks.getTask(i);
+            if (task.getDescription().contains(keyword)) {
+                relatedTasks.addTask(task);
+            }
+        }
+        return relatedTasks;
+    }
+
+    /**
+     * Method to execute command
+     * @param tasks The TaskList to work with.
+     * @param storage The Storage to save or load tasks (not used here)
+     * @param ui The messages the user will see
+     * @return system message
+     * @throws IOException
+     */
+    @Override
+    public String execute(TaskList tasks, Storage storage, Ui ui) throws IOException {
+        if (isEmptyKeyword()) {
+            return ui.showError("OOPS!!! The description of a find cannot be empty.");
+        }
+        TaskList relatedTasks = getMatchingTasks(tasks);
+        if (relatedTasks.getSize() > 0) {
+            return ui.showMatchedTasks(relatedTasks);
+        } else {
+            return ui.showNoMatchMessage(keyword);
+        }
+    }
+}

--- a/src/main/java/commands/TodoCommand.java
+++ b/src/main/java/commands/TodoCommand.java
@@ -1,0 +1,81 @@
+package commands;
+
+import store.Storage;
+import store.TaskList;
+import store.Todo;
+import ui.Ui;
+
+import java.io.IOException;
+
+/**
+ * Class representing the Todo command
+ */
+public class TodoCommand extends Command {
+
+    private String detailsWithNoSpace;
+    private Todo todoTask;
+    /**
+     * Constructor for todo command
+     * @param details of command
+     */
+    public TodoCommand(String details) {
+        super(details);
+        detailsWithNoSpace = details.trim();
+        todoTask = new Todo(details);
+    }
+
+    /**
+     * Method to execute command
+     * @param tasks The TaskList to work with.
+     * @param storage The Storage to save or load tasks
+     * @param ui The messages the user will see
+     * @return system message
+     * @throws IOException
+     */
+    @Override
+    public String execute(TaskList tasks, Storage storage, Ui ui) throws IOException {
+        if (detailsWithNoSpace.isEmpty()) {
+            return showErrorMessage(ui);
+        }
+        addTodoTask(tasks);
+        saveTaskList(tasks, storage);
+        return showTodoTaskMessage(ui, tasks);
+    }
+
+    /**
+     * Method to show error message from empty details
+     * @param ui
+     * @return system message
+     */
+    public String showErrorMessage(Ui ui) {
+        return ui.showError("OOPS!!! The description of a todo cannot be empty.");
+    }
+
+    /**
+     * Method to add todo task
+     * @param tasks
+     */
+    public void addTodoTask(TaskList tasks) {
+        tasks.addTask(todoTask);
+    }
+
+    /**
+     * Method to save tasks
+     * @param tasks
+     * @param storage
+     * @throws IOException
+     */
+    public void saveTaskList(TaskList tasks, Storage storage) throws IOException {
+        super.saveTasks(tasks, storage);
+    }
+
+    /**
+     * Method to return system message
+     * @param ui
+     * @param tasks
+     * @return system message
+     */
+    public String showTodoTaskMessage(Ui ui, TaskList tasks) {
+        return ui.showTaskAdded(todoTask, tasks.getSize());
+    }
+}

--- a/src/main/java/commands/UnmarkCommand.java
+++ b/src/main/java/commands/UnmarkCommand.java
@@ -8,19 +8,18 @@ import ui.Ui;
 import java.io.IOException;
 
 /**
- * Class representing the Mark command
+ * Class representing the Unmark command
  */
-public class MarkCommand extends Command {
-
-    private int markIndex;
+public class UnmarkCommand extends Command {
+    private int unmarkIndex;
 
     /**
-     * Constructor for MarkCommand
-     * @param details of command
+     * Constructor for UnmarkCommand
+     * @param details of task
      */
-    public MarkCommand(String details) {
+    public UnmarkCommand(String details) {
         super(details);
-        this.markIndex = Integer.parseInt(details) - 1;
+        this.unmarkIndex = Integer.parseInt(details) - 1;
     }
 
     /**
@@ -32,9 +31,9 @@ public class MarkCommand extends Command {
      * @throws IOException
      */
     @Override
-    public String execute(TaskList tasks, Storage storage, Ui ui) throws IOException {
-        tasks.markTaskAsDone(markIndex);
+    public String execute(TaskList tasks, Storage storage,Ui ui) throws IOException {
+        tasks.markTaskAsNotDone(unmarkIndex);
         super.saveTasks(tasks, storage);
-        return ui.showTaskMarked(tasks.getTask(markIndex));
+        return ui.showTaskUnmarked(tasks.getTask(unmarkIndex));
     }
 }

--- a/src/main/java/ui/Dusty.java
+++ b/src/main/java/ui/Dusty.java
@@ -49,9 +49,6 @@ public class Dusty {
     public TaskList getTasks() {
         return this.tasks;
     }
-    public String getResponse(String input) {
-        return "Dusty heard: " + input;
-    }
 
     public static void main(String[] args) {
         System.out.println("Hello!");

--- a/src/test/java/ui/DustyTest.java
+++ b/src/test/java/ui/DustyTest.java
@@ -52,7 +52,7 @@ public class DustyTest {
             Hello! I'm Dusty
             How can I help you?
             _______________
-            Invalid input or error processing command. Note that date and time should be in dd/mm/yyyy tt/mm format
+            Invalid input or error processing command. Note that date and time should be in dd/mm/yyyy ttmm format
             Bye! See you next time!""";
 
         runDusty(input);


### PR DESCRIPTION
Currently, Parser.java handles all command logic directly, making it lengthy and difficult to maintain. Each command is processed within a large switch statement, leading to long method and violation of SLAP.

This needs to change because having all command logic in one place reduces modularity and makes extending or modifying command behavior cumbersome.

Extract command execution logic into separate classes which extends from Command.java. Modify Parser.java to match these changes.

This is done to improve code quality by following SLAP.